### PR TITLE
Fix binary read version tag check

### DIFF
--- a/src/Ume/SOA_Idx_Mesh.cc
+++ b/src/Ume/SOA_Idx_Mesh.cc
@@ -15,6 +15,8 @@
 
 #include "Ume/SOA_Idx_Mesh.hh"
 #include "Ume/soa_idx_helpers.hh"
+#include "Ume/utils.hh"
+
 #include <istream>
 #include <ostream>
 
@@ -24,7 +26,7 @@ namespace SOA_Idx {
 /* --------------------------------- Mesh -----------------------------------*/
 
 Mesh::Mesh()
-    : Mesh_Base(), corners{this}, edges{this}, faces{this}, points{this},
+    : Mesh_Base(), dump_iotas{false}, corners{this}, edges{this}, faces{this}, points{this},
       sides{this}, zones{this}, iotas{this} {}
 
 std::ostream &operator<<(std::ostream &os, Mesh::Geometry_Type const &geo) {
@@ -59,11 +61,14 @@ void Mesh::write(std::ostream &os) const {
 }
 
 void Mesh::read(std::istream &is) {
-  read_bin(is, ivtag);
+  ivtag = read_vtag(is, "Input version");
   read_bin(is, mype);
   read_bin(is, numpe);
   read_bin(is, geo);
-  read_bin(is, dump_iotas);
+  
+  if (ivtag >= UME_VERSION_2)
+    read_bin(is, dump_iotas);
+
   points.read(is);
   edges.read(is);
   faces.read(is);

--- a/src/Ume/SOA_Idx_Mesh.hh
+++ b/src/Ume/SOA_Idx_Mesh.hh
@@ -12,17 +12,9 @@
 /*!
   \file Ume/SOA_Idx_Mesh.hh
 */
+
 #ifndef UME_SOA_IDX_MESH_HH
 #define UME_SOA_IDX_MESH_HH 1
-
-/*! Input version tags. These document breaking changes in UME input
- * decks. All inputs of a particular version are valid up to the next
- * version number. */
-
-/*! 1.0.0 release tag. */
-#define UME_VERSION_1 20230330
-/*! The latest input version tag. Inputs include iota information. */
-#define UME_VERSION_2 20250722
 
 #include "Ume/Mesh_Base.hh"
 #include "Ume/SOA_Entity.hh"

--- a/src/Ume/utils.cc
+++ b/src/Ume/utils.cc
@@ -13,6 +13,8 @@
   \file Ume/utils.cc
 */
 
+#include "Ume/utils.hh"
+
 #include <cstdlib>
 #include <iostream>
 #include <sys/types.h>
@@ -23,6 +25,36 @@
 #endif
 
 namespace Ume {
+
+int read_vtag(std::istream &is, char const *const expect) {
+  /* If "Input version" tag is absent, default to old input version. */
+  char const c1 = static_cast<char>(is.peek());
+  if (c1 != 'I')
+    return UME_VERSION_1;
+
+  char tagname[25];
+  is.get(tagname, 23);
+  std::string ts(tagname);
+
+  while (ts.back() == ':' || ts.back() == ' ')
+    ts.pop_back();
+
+  if (ts != std::string(expect)) {
+    std::cerr << "Expecting tag \"" << expect << "\", got \"" << ts << "\""
+              << std::endl;
+    exit(EXIT_FAILURE);
+  }
+
+  int val = -1;
+  is >> val;
+  if (!is) {
+    std::cerr << "Didn't find an integer after tag \"" << ts << "\""
+              << std::endl;
+    exit(EXIT_FAILURE);
+  }
+  is >> std::ws;
+  return val;
+}
 
 void debug_attach_point(int const mype) {
   int release = 0;

--- a/src/Ume/utils.hh
+++ b/src/Ume/utils.hh
@@ -13,6 +13,15 @@
 \file Ume/utils.hh
 */
 
+/*! Input version tags. These document breaking changes in UME input
+ * decks. All inputs of a particular version are valid up to the next
+ * version number. */
+
+/*! 1.0.0 release tag. */
+#define UME_VERSION_1 20230330
+/*! The latest input version tag. Inputs include iota information. */
+#define UME_VERSION_2 20250722
+
 #include <istream>
 #include <limits>
 #include <memory>
@@ -86,6 +95,8 @@ template <class T> void read_bin(std::istream &is, std::vector<T> &data) {
   }
   Ume::skip_line(is);
 }
+
+int read_vtag(std::istream &is, char const *const expect);
 
 inline std::string ltrim(const std::string &s) {
   const std::string WHITESPACE{" \n\r\t\f\v"};

--- a/src/txt2bin.cc
+++ b/src/txt2bin.cc
@@ -127,36 +127,6 @@ int read_tag(std::istream &is, char const *const expect) {
   return val;
 }
 
-int read_vtag(std::istream &is, char const *const expect) {
-  /* If "Input version" tag is absent, default to old input version. */
-  char const c1 = static_cast<char>(is.peek());
-  if (c1 != 'I')
-    return UME_VERSION_1;
-
-  char tagname[25];
-  is.get(tagname, 23);
-  std::string ts(tagname);
-
-  while (ts.back() == ':' || ts.back() == ' ')
-    ts.pop_back();
-
-  if (ts != std::string(expect)) {
-    std::cerr << "Expecting tag \"" << expect << "\", got \"" << ts << "\""
-              << std::endl;
-    exit(EXIT_FAILURE);
-  }
-
-  int val = -1;
-  is >> val;
-  if (!is) {
-    std::cerr << "Didn't find an integer after tag \"" << ts << "\""
-              << std::endl;
-    exit(EXIT_FAILURE);
-  }
-  is >> std::ws;
-  return val;
-}
-
 bool read_bool_tag(std::istream &is, char const *const expect) {
   char tagname[25];
   is.get(tagname, 23);
@@ -554,7 +524,7 @@ void read_mpi(std::istream &is, Entity &e) {
 }
 
 int read(std::istream &is, Mesh &m) {
-  m.ivtag = read_vtag(is, "Input version");
+  m.ivtag = Ume::read_vtag(is, "Input version");
   m.numpe = read_tag(is, "Total ranks");
   m.mype = read_tag(is, "This rank");
   int ndims = read_tag(is, "Num dims");


### PR DESCRIPTION
#7 took care of the case of reading in an UME txt file and converting it to a binary file, but did not handle the case of reading in an existing binary input file.

This PR fixes reading in a binary UME input that was broken in #7 which gave a `bad_alloc` on `mesh.read(is)` since the mesh attempted to read in a version tag even if it did not exist in the binary file (since the binary file was `UME_VERSION_1`).

```
#0  0x00001532177ec52f in raise () from /lib64/libc.so.6
#1  0x00001532177bfe65 in abort () from /lib64/libc.so.6
#2  0x00001532183e6b1b in __gnu_cxx::__verbose_terminate_handler () at ../../../../gcc-13.2.0/libstdc++-v3/libsupc++/vterminate.cc:95
#3  0x00001532183f62ca in __cxxabiv1::__terminate (handler=<optimized out>) at ../../../../gcc-13.2.0/libstdc++-v3/libsupc++/eh_terminate.cc:48
#4  0x00001532183f6335 in std::terminate () at ../../../../gcc-13.2.0/libstdc++-v3/libsupc++/eh_terminate.cc:58
#5  0x00001532183f6588 in __cxxabiv1::__cxa_throw (obj=<optimized out>, tinfo=0x15321878bba8 <typeinfo for std::bad_alloc>, 
    dest=0x1532183f4930 <std::bad_alloc::~bad_alloc()>) at ../../../../gcc-13.2.0/libstdc++-v3/libsupc++/eh_throw.cc:98
#6  0x00001532183e6726 in operator new (sz=<error reading variable: dwarf2_find_location_expression: Corrupted DWARF expression.>)
    at /tmp/gcc-13.2.0-build/build-gcc/x86_64-pc-linux-gnu/libstdc++-v3/include/bits/exception.h:62
#7  0x000000000041753e in Ume::read_bin<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > (is=..., data=...)
    at /vast/home/jereddt/UME-Renumbering/src/Ume/utils.hh:58
#8  0x0000000000426c0a in Ume::SOA_Idx::Points::read (this=0x7ffc976eda08, is=...)
    at /vast/home/jereddt/UME-Renumbering/src/Ume/SOA_Idx_Points.cc:42
#9  0x000000000042612b in Ume::SOA_Idx::Mesh::read (this=0x7ffc976ed710, is=...) at /vast/home/jereddt/UME-Renumbering/src/Ume/SOA_Idx_Mesh.cc:67
#10 0x0000000000404a92 in read_mesh (basename=0x7ffc976ef7e7 "../AggAdv_64_00001", mype=0, mesh=...)
    at /vast/home/jereddt/UME-Renumbering/src/ume_mpi.cc:181
#11 0x0000000000404190 in main (argc=2, argv=0x7ffc976edee8) at /vast/home/jereddt/UME-Renumbering/src/ume_mpi.cc:64
```