### PR TITLE
Handle version case where only binary file with no version header exists

### DIFF
--- a/src/Ume/SOA_Idx_Mesh.hh
+++ b/src/Ume/SOA_Idx_Mesh.hh
@@ -16,6 +16,15 @@
 #ifndef UME_SOA_IDX_MESH_HH
 #define UME_SOA_IDX_MESH_HH 1
 
+/*! Input version tags. These document breaking changes in UME input
+ * decks. All inputs of a particular version are valid up to the next
+ * version number. */
+
+/*! 1.0.0 release tag. */
+#define UME_VERSION_1 20230330
+/*! The latest input version tag. Inputs include iota information. */
+#define UME_VERSION_2 20250722
+
 #include "Ume/Mesh_Base.hh"
 #include "Ume/SOA_Entity.hh"
 #include "Ume/SOA_Idx_Corners.hh"
@@ -38,6 +47,7 @@ using Types = Ume::DS_Types::Types;
 struct Mesh : public Mesh_Base {
   enum Geometry_Type { CARTESIAN, CYLINDRICAL, SPHERICAL };
   int ivtag;
+  bool version_header;
   int mype;
   int numpe;
   Geometry_Type geo;

--- a/src/Ume/utils.cc
+++ b/src/Ume/utils.cc
@@ -13,8 +13,6 @@
   \file Ume/utils.cc
 */
 
-#include "Ume/utils.hh"
-
 #include <cstdlib>
 #include <iostream>
 #include <sys/types.h>
@@ -25,36 +23,6 @@
 #endif
 
 namespace Ume {
-
-int read_vtag(std::istream &is, char const *const expect) {
-  /* If "Input version" tag is absent, default to old input version. */
-  char const c1 = static_cast<char>(is.peek());
-  if (c1 != 'I')
-    return UME_VERSION_1;
-
-  char tagname[25];
-  is.get(tagname, 23);
-  std::string ts(tagname);
-
-  while (ts.back() == ':' || ts.back() == ' ')
-    ts.pop_back();
-
-  if (ts != std::string(expect)) {
-    std::cerr << "Expecting tag \"" << expect << "\", got \"" << ts << "\""
-              << std::endl;
-    exit(EXIT_FAILURE);
-  }
-
-  int val = -1;
-  is >> val;
-  if (!is) {
-    std::cerr << "Didn't find an integer after tag \"" << ts << "\""
-              << std::endl;
-    exit(EXIT_FAILURE);
-  }
-  is >> std::ws;
-  return val;
-}
 
 void debug_attach_point(int const mype) {
   int release = 0;

--- a/src/Ume/utils.hh
+++ b/src/Ume/utils.hh
@@ -13,15 +13,6 @@
 \file Ume/utils.hh
 */
 
-/*! Input version tags. These document breaking changes in UME input
- * decks. All inputs of a particular version are valid up to the next
- * version number. */
-
-/*! 1.0.0 release tag. */
-#define UME_VERSION_1 20230330
-/*! The latest input version tag. Inputs include iota information. */
-#define UME_VERSION_2 20250722
-
 #include <istream>
 #include <limits>
 #include <memory>
@@ -95,8 +86,6 @@ template <class T> void read_bin(std::istream &is, std::vector<T> &data) {
   }
   Ume::skip_line(is);
 }
-
-int read_vtag(std::istream &is, char const *const expect);
 
 inline std::string ltrim(const std::string &s) {
   const std::string WHITESPACE{" \n\r\t\f\v"};

--- a/src/txt2bin.cc
+++ b/src/txt2bin.cc
@@ -127,6 +127,36 @@ int read_tag(std::istream &is, char const *const expect) {
   return val;
 }
 
+int read_vtag(std::istream &is, char const *const expect) {
+  /* If "Input version" tag is absent, default to old input version. */
+  char const c1 = static_cast<char>(is.peek());
+  if (c1 != 'I')
+    return UME_VERSION_1;
+
+  char tagname[25];
+  is.get(tagname, 23);
+  std::string ts(tagname);
+
+  while (ts.back() == ':' || ts.back() == ' ')
+    ts.pop_back();
+
+  if (ts != std::string(expect)) {
+    std::cerr << "Expecting tag \"" << expect << "\", got \"" << ts << "\""
+              << std::endl;
+    exit(EXIT_FAILURE);
+  }
+
+  int val = -1;
+  is >> val;
+  if (!is) {
+    std::cerr << "Didn't find an integer after tag \"" << ts << "\""
+              << std::endl;
+    exit(EXIT_FAILURE);
+  }
+  is >> std::ws;
+  return val;
+}
+
 bool read_bool_tag(std::istream &is, char const *const expect) {
   char tagname[25];
   is.get(tagname, 23);
@@ -524,7 +554,7 @@ void read_mpi(std::istream &is, Entity &e) {
 }
 
 int read(std::istream &is, Mesh &m) {
-  m.ivtag = Ume::read_vtag(is, "Input version");
+  m.ivtag = read_vtag(is, "Input version");
   m.numpe = read_tag(is, "Total ranks");
   m.mype = read_tag(is, "This rank");
   int ndims = read_tag(is, "Num dims");


### PR DESCRIPTION
Fixes #12 

This is currently a workaround that I'd like to make more elegant.

It currently checks whether the first int read in from the UME binary file is in fact an existing UME_VERSION. If not, it assumes that value is actually the value of `mype`, sets the version to be `UME_VERSION_1` and adds a flag to skip the attempt to read the `dump_iotas` boolean, while simultaneously setting it to false so that no attempt to actually read iotas is actually made.

I am very open to alternative solutions, but wanted to at least have this branch working for a few students who were having issues since they only have UME binary inputs (and no umetxt inputs to re-generate an UME binary with a version header) generated from before there was a version header