### PR TITLE
Kokkos versioning requirements

### DIFF
--- a/cmake/pkgs/KokkosSupport.cmake
+++ b/cmake/pkgs/KokkosSupport.cmake
@@ -1,4 +1,5 @@
-find_package(Kokkos REQUIRED)
+find_package(Kokkos 4.6 REQUIRED)
+message(STATUS "Found Kokkos: ${Kokkos_DIR} (version \"${Kokkos_VERSION}\")")
 
 set(COMMON_LINK_LIBRARIES Kokkos::kokkos)
 # Link CUDART for CUDA backend


### PR DESCRIPTION
Require Kokkos v4.6 minimum and print status message at configure. @JDTruj2018 @davidallendj 